### PR TITLE
Added try/except for python3 compatibility.

### DIFF
--- a/tqdm.py
+++ b/tqdm.py
@@ -97,4 +97,9 @@ def tqdm(iterable, desc='', total=None, leave=False, mininterval=0.5, miniters=1
 
 def trange(*args, **kwargs):
     """A shortcut for writing tqdm(xrange)"""
-    return tqdm(xrange(*args), **kwargs)
+    try:
+        f = xrange
+    except NameError:
+        f = range
+
+    return tqdm(f(*args), **kwargs)


### PR DESCRIPTION
`xrange` is not available in python3 and has been replaced by `range`
