### PR TITLE
Use backspace (\b) instead of carriage return (\r)

### DIFF
--- a/tqdm.py
+++ b/tqdm.py
@@ -47,7 +47,8 @@ class StatusPrinter(object):
         self.last_printed_len = 0
     
     def print_status(self, s):
-        self.file.write('\r'+s+' '*max(self.last_printed_len-len(s), 0))
+        b = '\b' * self.last_printed_len
+        self.file.write(b + s + ' ' * max(self.last_printed_len - len(s), 0))
         self.file.flush()
         self.last_printed_len = len(s)
 


### PR DESCRIPTION
tqdm uses `\r` to clear the most recently printed line. However, if the console width is less than the length of the string, then the string is printed on multiple lines and `\r` doesn't work -- it actually leaves artifacts behind.

By using backspace `\b` for each printed character, tqdm can clear output over multiple lines.

Note this problem can arise either because the string is long or the console width has been made artificially short.

Example:

```python
long_desc = 'A very long' + '.' * 100 + 'description!'
for i in tqdm.tqdm(xrange(10000), desc=long_desc):
    time.sleep(0.0001)

```