### PR TITLE
Fix 'unorderable type' error in Python 3

### DIFF
--- a/tqdm.py
+++ b/tqdm.py
@@ -17,7 +17,7 @@ def format_meter(n, total, elapsed):
     # n - number of finished iterations
     # total - total number of iterations, or None
     # elapsed - number of seconds passed since start
-    if n > total:
+    if total and n > total:
         total = None
     
     elapsed_str = format_interval(elapsed)


### PR DESCRIPTION
When total is None there is an error in Python 3:

```
Traceback (most recent call last):
  ...
  File "tqdm.py", line 18, in format_meter
    if n > total:
TypeError: unorderable types: int() > NoneType()
```

This PR fixes this by first checking if total is valid.
